### PR TITLE
Item spawn / dupe exploit fix

### DIFF
--- a/src/main/java/com/reliableplugins/printer/PrinterPlayer.java
+++ b/src/main/java/com/reliableplugins/printer/PrinterPlayer.java
@@ -153,6 +153,7 @@ public class PrinterPlayer
         }
 
         // Set gamemode and inventory back to initials
+        player.closeInventory(); // prevents held item from staying while exitting print mode, inside inventory
         player.setGameMode(initialGamemode);
         player.getInventory().setContents(initialInventory);
         player.getInventory().setArmorContents(initialArmor);


### PR DESCRIPTION
Close player inventory when exiting printer mode

Prevents held item from staying while exiting print mode, inside inventory

see Issue #24